### PR TITLE
chore: enable renovate and add configurations

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,75 @@
 {
-  "enabled": false
+  "rangeStrategy": "bump",
+  "separateMajorMinor": false,
+  "prHourlyLimit": 2,
+  "timezone": "UTC",
+  "schedule": [
+    "after 9pm on saturday"
+  ],
+  "baseBranches": [
+    "master"
+  ],
+  "ignoreDeps": [
+    "@types/node"
+  ],
+  "packageFiles": [
+    "package.json"
+  ],
+  "major": {
+    "devDependencies": {
+      "enabled": false
+    }
+  },
+  "packageRules": [
+    {
+      "depTypeList": ["dependencies"],
+      "packagePatterns": [
+        "^@angular\/.*"
+      ],
+      "groupName": "@angular"
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "packagePatterns": [
+        "^@angular.*"
+      ],
+      "groupName": "@angular-dev"
+    },
+    {
+      "packageNames": [
+        "typescript"
+      ],
+      "updateTypes": "patch"
+    },
+    {
+      "packageNames": [
+        "^@ngxs\/.*"
+      ],
+      "groupName": "@ngxs"
+    },
+    {
+      "packageNames": [
+        "^karma.*"
+      ],
+      "groupName": "karma"
+    },
+    {
+      "packageNames": [
+        "^jasmine.*"
+      ],
+      "groupName": "jasmine"
+    },
+    {
+      "packageNames": [
+        "^@types\/.*"
+      ],
+      "groupName": "@types"
+    },
+    {
+      "packageNames": [
+        "^@ionic.*"
+      ],
+      "groupName": "@ionic"
+    }
+  ]
 }


### PR DESCRIPTION
https://renovatebot.com/docs/configuration-options/

Explantaion about important configurations:
- `rangeStrategy: "bump"` - bump the range even if the new version satisfies the existing range
- `separateMajorMinor: false` - will upgrade dependencies to latest release only, and not separate major/minor branches.
- `schedule` - run weekly upgrade checks after 9PM on Saturday, UTC time.
- `ignoreDeps: [ "@types/node" ]` - prevent upgrades of the node typings.
- `major: { "devDependencies": { "enabled": false } }` - don't upgrade major versions in devDependencies.
- `packageRules`:
  1. `@angular/*` (dependencies) -> `@angular`
  2. `@angular*` (devDependencies) -> `@angular-dev` (including `@angular-devkit`)
  3. `typescript` - update only patch versions
  4. `@ngxs/*` -> @ngxs
  5. `karma*` -> karma
  6. `jasmine*` -> jasmine
  7. `@types/*` -> @types
  8. `@ionic*` -> @ionic
