### PR TITLE
Support State Tokens used for StateModel names

### DIFF
--- a/src/lib/internals.ts
+++ b/src/lib/internals.ts
@@ -28,7 +28,7 @@ function transformKeyOption(key: StorageKey): string[] {
     key = [key];
   }
 
-  return key.map((token: string | StateClass) => {
+  return key.map((token: string | StateClass | StateToken<any>) => {
     if (typeof token === 'string') {
       return token;
     } else if (token instanceof StateToken) {
@@ -36,6 +36,11 @@ function transformKeyOption(key: StorageKey): string[] {
     }
 
     const options = (token as any)[META_OPTIONS_KEY];
+
+    if (options.name instanceof StateToken) {
+      return options.name.getName();
+    }
+
     return options.name;
   });
 }


### PR DESCRIPTION
It is possible for a `StateToken` to be used for the name of a `StateModel`. Therefore, check for the presence of a `StateToken` in the name, otherwise fallback to a string.

Also, I updated the signature of the map to match the main StoragePlugin's signature.